### PR TITLE
Add `and_not` function

### DIFF
--- a/src/bitop.rs
+++ b/src/bitop.rs
@@ -1,10 +1,87 @@
 use crate::{BST_BITS, BitSliceType, INLINE_SLICE_PARTS, SmolBitSet};
 
 use core::iter;
-use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
+
+macro_rules! shortening_bitop_fn_body {
+    ($lhs:ident, $rhs:ident, $opa:path) => {
+        match ($lhs.is_inline(), $rhs.is_inline()) {
+            (true, _) => unsafe {
+                let mut lhs = $lhs.get_inline_data_unchecked();
+                let rhs = $rhs.get_inlineable_start();
+                $opa(&mut lhs, rhs);
+                $lhs.write_inline_data_unchecked(lhs);
+            },
+            (false, false) => {
+                let lhs = unsafe { $lhs.as_slice_mut_unchecked() };
+                let rhs = unsafe { $rhs.as_slice_unchecked() };
+
+                // in case lhs > rhs we need to have extra elements
+                let rhs_iter = rhs.iter().chain(iter::repeat(&0));
+
+                for (lhs, rhs) in lhs.iter_mut().zip(rhs_iter) {
+                    $opa(lhs, *rhs);
+                }
+            }
+            (false, true) => {
+                let lhs = unsafe { $lhs.as_slice_mut_unchecked() };
+                let rhs = unsafe { $rhs.get_inline_data_unchecked() };
+
+                lhs.iter_mut().enumerate().for_each(|(idx, lhs)| {
+                    $opa(
+                        lhs,
+                        rhs.checked_shr((idx * BST_BITS) as u32).unwrap_or(0) as BitSliceType,
+                    );
+                });
+            }
+        }
+    };
+}
+
+macro_rules! extending_bitop_fn_body {
+    ($lhs:ident, $rhs:ident, $opa:path) => {
+        match ($lhs.is_inline(), $rhs.is_inline()) {
+            (true, true) => unsafe {
+                let mut lhs = $lhs.get_inline_data_unchecked();
+                let rhs = $rhs.get_inline_data_unchecked();
+                $opa(&mut lhs, rhs);
+                $lhs.write_inline_data_unchecked(lhs);
+            },
+            (_, false) => {
+                let rhs_hb = $rhs.highest_set_bit();
+                if rhs_hb > $lhs.highest_set_bit() {
+                    $lhs.ensure_capacity(rhs_hb);
+                }
+
+                let lhs = unsafe { $lhs.as_slice_mut_unchecked() };
+                let rhs = unsafe { $rhs.as_slice_unchecked() };
+
+                assert!(lhs.len() >= rhs.len());
+
+                // in case lhs > rhs we need to have extra elements
+                let rhs_iter = rhs.iter().chain(iter::repeat(&0));
+
+                for (lhs, rhs) in lhs.iter_mut().zip(rhs_iter) {
+                    $opa(lhs, *rhs);
+                }
+            }
+            (false, true) => {
+                let lhs = unsafe { $lhs.as_slice_mut_unchecked() };
+                let rhs = unsafe { $rhs.get_inline_data_unchecked() };
+
+                lhs.iter_mut()
+                    .enumerate()
+                    .take(INLINE_SLICE_PARTS)
+                    .for_each(|(idx, lhs)| {
+                        $opa(lhs, (rhs >> (idx * BST_BITS)) as BitSliceType);
+                    });
+            }
+        }
+    };
+}
 
 macro_rules! impl_bitop {
-    ($($OP:ident :: $op:ident, $OPA:ident :: $opa:ident),+) => {$(
+    ($($OP:ident :: $op:ident, $OPA:ident :: $opa:ident, $body_macro:path;)+) => {$(
         impl $OP<Self> for SmolBitSet {
             type Output = Self;
 
@@ -23,9 +100,6 @@ macro_rules! impl_bitop {
             }
         }
 
-        impl_bitop!(@ref $OP :: $op, $OPA :: $opa);
-    )*};
-    (@ref $OP:ident :: $op:ident, $OPA:ident :: $opa:ident) => {
         impl $OP<&Self> for SmolBitSet {
             type Output = Self;
 
@@ -39,55 +113,27 @@ macro_rules! impl_bitop {
 
         impl $OPA<&Self> for SmolBitSet {
             fn $opa(&mut self, rhs: &Self) {
-                match (self.is_inline(), rhs.is_inline()) {
-                    (true, true) => unsafe {
-                        let lhs = self.get_inline_data_unchecked();
-                        let rhs = rhs.get_inline_data_unchecked();
-                        self.write_inline_data_unchecked(lhs.$op(rhs));
-                    },
-                    (_, false) => {
-                        let rhs_hb = rhs.highest_set_bit();
-                        if rhs_hb > self.highest_set_bit() {
-                            self.ensure_capacity(rhs_hb);
-                        }
-
-                        let lhs = unsafe { self.as_slice_mut_unchecked() };
-                        let rhs = unsafe { rhs.as_slice_unchecked() };
-
-                        assert!(lhs.len() >= rhs.len());
-
-                        // in case lhs > rhs we need to have extra elements
-                        let rhs_iter = rhs.iter().chain(iter::repeat(&0));
-
-                        for (lhs, rhs) in lhs.iter_mut().zip(rhs_iter) {
-                            (*lhs).$opa(*rhs);
-                        }
-                    }
-                    (false, true) => {
-                        let lhs = unsafe { self.as_slice_mut_unchecked() };
-                        let rhs = unsafe { rhs.get_inline_data_unchecked() };
-
-                        lhs.iter_mut()
-                            .enumerate()
-                            .take(INLINE_SLICE_PARTS)
-                            .for_each(|(idx, lhs)| {
-                                (*lhs).$opa((rhs >> (idx * BST_BITS)) as BitSliceType);
-                            });
-                    }
+                fn op<T>(lhs: &mut T, rhs: T)
+                where
+                    T: $OPA<T>
+                {
+                    (*lhs).$opa(rhs);
                 }
+
+                $body_macro!(self, rhs, op);
             }
         }
-    };
+    )*};
 }
 
 impl_bitop! {
-    BitOr::bitor, BitOrAssign::bitor_assign,
-    BitAnd::bitand, BitAndAssign::bitand_assign,
-    BitXor::bitxor, BitXorAssign::bitxor_assign
+    BitOr::bitor, BitOrAssign::bitor_assign, extending_bitop_fn_body;
+    BitAnd::bitand, BitAndAssign::bitand_assign, shortening_bitop_fn_body;
+    BitXor::bitxor, BitXorAssign::bitxor_assign, extending_bitop_fn_body;
 }
 
 macro_rules! impl_bitop_prim {
-    ($($OP:ident :: $op:ident, $OPA:ident :: $opa:ident, $t:ty),+) => {$(
+    ($($OP:ident :: $op:ident, $OPA:ident :: $opa:ident, $t:ty;)+) => {$(
         impl $OP<$t> for SmolBitSet {
             type Output = Self;
 
@@ -106,9 +152,6 @@ macro_rules! impl_bitop_prim {
             }
         }
 
-        impl_bitop_prim!(@ref $OP :: $op, $OPA :: $opa, $t);
-    )*};
-    (@ref $OP:ident :: $op:ident, $OPA:ident :: $opa:ident, $t:ty) => {
         impl $OP<&$t> for SmolBitSet {
             type Output = Self;
 
@@ -124,14 +167,39 @@ macro_rules! impl_bitop_prim {
                 self.$opa(*rhs)
             }
         }
-    };
+    )*};
     ($($t:ty),+) => {$(
         impl_bitop_prim!{
-            BitOr::bitor, BitOrAssign::bitor_assign, $t,
-            BitAnd::bitand, BitAndAssign::bitand_assign, $t,
-            BitXor::bitxor, BitXorAssign::bitxor_assign, $t
+            BitOr::bitor, BitOrAssign::bitor_assign, $t;
+            BitAnd::bitand, BitAndAssign::bitand_assign, $t;
+            BitXor::bitxor, BitXorAssign::bitxor_assign, $t;
         }
     )*};
 }
 
 impl_bitop_prim!(u8, u16, u32, u64, u128, usize);
+
+impl SmolBitSet {
+    /// Unsets all bits set on the `rhs` [`SmolBitSet`].
+    ///
+    /// This is equivalent to `self & !rhs` with integers.
+    #[must_use]
+    pub fn and_not(mut self, rhs: &Self) -> Self {
+        self.and_not_assign(rhs);
+        self
+    }
+
+    /// Unsets all bits set on the `rhs` [`SmolBitSet`].
+    ///
+    /// This is equivalent to `*self &= !rhs` with integers.
+    pub fn and_not_assign(&mut self, rhs: &Self) {
+        fn op<T>(lhs: &mut T, rhs: T)
+        where
+            T: BitAndAssign + Not<Output = T>,
+        {
+            *lhs &= !rhs;
+        }
+
+        shortening_bitop_fn_body!(self, rhs, op);
+    }
+}


### PR DESCRIPTION
The `and_not` and `add_not_assign` functions perform the equivalent of `a & !b` and `a &= !b` with bitsets. `!b` has no sane value to return and I figured there were no other meaningful reasons to use that operator on its own.

There is no attempt for now to allow `bitset.and_not(int)` like the operators do and it's easy to get around this by using `bitset.and_not(&int.into())`.

This also refactors the `binop.rs` file to share some logic between this pseudo-operator function and the existing operators, as well as avoiding `short & long` from allocating. Also also refactors the operator tests to no longer care about the exact internal representation when all they try to assert is the bits.