### PR TITLE
sparse mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A library for dynamically sized bitsets with optimizations for memory usage.
 
-The first <code>usize::BITS - 1</code> bits are stored without incurring any heap allocations.\
+The first <code>usize::BITS - 2</code> bits are stored without incurring any heap allocations.\
 Any larger values dynamically allocate an appropriately sized `u32` slice on the heap.\
 Furthermore `SmolBitSet` has a niche optimization so `Option<SmolBitSet>` has the same size of 1 [`usize`].
 
@@ -16,3 +16,7 @@ Furthermore `SmolBitSet` has a niche optimization so `Option<SmolBitSet>` has th
 [crates.io version]: https://img.shields.io/crates/v/smolbitset.svg?style=flat-square
 [rust-version-badge]: https://img.shields.io/badge/rust-1.89.0+-93450a.svg?style=flat-square
 [rust-version-link]: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/
+
+## TODO
+- [ ] improve readme / crate level docs
+- [ ] add info about sparse mode to readme / crate level docs

--- a/src/bitop.rs
+++ b/src/bitop.rs
@@ -1,18 +1,85 @@
-use crate::{BST_BITS, BitSliceType, INLINE_SLICE_PARTS, SmolBitSet};
+use crate::bst_slice::BstSlice;
+use crate::{BST_BITS, BitSliceType, INLINE_SLICE_PARTS, Representation, SmolBitSet};
 
 use core::iter;
 use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 macro_rules! shortening_bitop_fn_body {
-    ($lhs:ident, $rhs:ident, $opa:path) => {
-        match ($lhs.is_inline(), $rhs.is_inline()) {
-            (true, _) => unsafe {
+    ($lhs:ident, $rhs:ident, $opa:path, $sparse_cond:path, $self_op:ident) => {
+        match ($lhs.representation(), $rhs.representation()) {
+            (Representation::SparseInline, Representation::SparseInline) => unsafe {
+                let lhs_flag = $lhs.get_inline_sparse_data_unchecked();
+                let rhs_flag = $rhs.get_inline_sparse_data_unchecked();
+
+                if $sparse_cond(lhs_flag, rhs_flag) {
+                    // result is still sparse and lhs already has the correct flag set
+                } else {
+                    // result is an empty set
+                    *$lhs = Self::new();
+                }
+            },
+            (
+                Representation::SparseInline,
+                Representation::NormalInline | Representation::NormalHeap,
+            ) => {
+                let lhs_flag = unsafe { $lhs.get_inline_sparse_data_unchecked() };
+                let target_elem = lhs_flag / BST_BITS as u32;
+                let target_shift = lhs_flag.rem_euclid(BST_BITS as u32);
+
+                let rhs_bst = BstSlice::new($rhs);
+                let rhs_slice = rhs_bst.slice();
+                let rhs_elem = rhs_slice.iter().nth(target_elem as usize).unwrap_or(&0);
+                let rhs_flag = ((rhs_elem >> target_shift) & 1) as u32 * lhs_flag;
+
+                if $sparse_cond(lhs_flag, rhs_flag) {
+                    // result is still sparse and lhs already has the correct flag set
+                } else {
+                    // result is an empty set
+                    *$lhs = Self::new();
+                }
+            }
+            (
+                Representation::NormalInline | Representation::NormalHeap,
+                Representation::SparseInline,
+            ) => {
+                let rhs_flag = unsafe { $rhs.get_inline_sparse_data_unchecked() };
+                let target_elem = rhs_flag / BST_BITS as u32;
+                let target_shift = rhs_flag.rem_euclid(BST_BITS as u32);
+
+                let lhs_bst = BstSlice::new($lhs);
+                let lhs_slice = lhs_bst.slice();
+                let lhs_elem = lhs_slice.iter().nth(target_elem as usize).unwrap_or(&0);
+                let lhs_flag = ((lhs_elem >> target_shift) & 1) as u32 * rhs_flag;
+
+                // TODO: clean up the duplication & possibly simplify conditions
+                if $sparse_cond(lhs_flag, rhs_flag) {
+                    if lhs_flag == rhs_flag {
+                        // result is sparse and lhs needs to be updated
+                        *$lhs = Self::new_flag(rhs_flag);
+                    } else {
+                        // result is not sparse, rhs_flag bit needs to be unset in lhs
+                        $lhs.and_not_assign(&(Self::new_small(1) << rhs_flag));
+                    }
+                } else {
+                    if lhs_flag != rhs_flag {
+                        // result is an empty set
+                        *$lhs = Self::new();
+                    } else {
+                        // result is not sparse, rhs_flag bit needs to be unsed in lhs
+                        $lhs.and_not_assign(&(Self::new_small(1) << rhs_flag));
+                    }
+                }
+            }
+            (
+                Representation::NormalInline,
+                Representation::NormalInline | Representation::NormalHeap,
+            ) => unsafe {
                 let mut lhs = $lhs.get_inline_data_unchecked();
                 let rhs = $rhs.get_inlineable_start();
                 $opa(&mut lhs, rhs);
                 $lhs.write_inline_data_unchecked(lhs);
             },
-            (false, false) => {
+            (Representation::NormalHeap, Representation::NormalHeap) => {
                 let lhs = unsafe { $lhs.as_slice_mut_unchecked() };
                 let rhs = unsafe { $rhs.as_slice_unchecked() };
 
@@ -23,7 +90,7 @@ macro_rules! shortening_bitop_fn_body {
                     $opa(lhs, *rhs);
                 }
             }
-            (false, true) => {
+            (Representation::NormalHeap, Representation::NormalInline) => {
                 let lhs = unsafe { $lhs.as_slice_mut_unchecked() };
                 let rhs = unsafe { $rhs.get_inline_data_unchecked() };
 
@@ -39,15 +106,50 @@ macro_rules! shortening_bitop_fn_body {
 }
 
 macro_rules! extending_bitop_fn_body {
-    ($lhs:ident, $rhs:ident, $opa:path) => {
-        match ($lhs.is_inline(), $rhs.is_inline()) {
-            (true, true) => unsafe {
+    ($lhs:ident, $rhs:ident, $opa:path, $sparse_cond:path, $self_op:ident) => {
+        match ($lhs.representation(), $rhs.representation()) {
+            (Representation::SparseInline, Representation::SparseInline) => unsafe {
+                let lhs_flag = $lhs.get_inline_sparse_data_unchecked();
+                let rhs_flag = $rhs.get_inline_sparse_data_unchecked();
+
+                if $sparse_cond(lhs_flag, rhs_flag) {
+                    if lhs_flag == rhs_flag {
+                        // result is still sparse and lhs is already correct
+                    } else {
+                        // result is not sparse, must contain both flags
+                        let mut res = $lhs.as_normal();
+                        $opa(&mut res, $rhs.as_normal());
+                        *$lhs = res;
+                    }
+                } else {
+                    // result is an empty set
+                    *$lhs = Self::new();
+                }
+            },
+            (
+                Representation::SparseInline,
+                Representation::NormalInline | Representation::NormalHeap,
+            ) => {
+                let mut lhs_normalized = $lhs.as_normal();
+                Self::$self_op(&mut lhs_normalized, $rhs);
+                *$lhs = lhs_normalized;
+            }
+            (
+                Representation::NormalInline | Representation::NormalHeap,
+                Representation::SparseInline,
+            ) => {
+                Self::$self_op($lhs, $rhs.as_normal());
+            }
+            (Representation::NormalInline, Representation::NormalInline) => unsafe {
                 let mut lhs = $lhs.get_inline_data_unchecked();
                 let rhs = $rhs.get_inline_data_unchecked();
                 $opa(&mut lhs, rhs);
                 $lhs.write_inline_data_unchecked(lhs);
             },
-            (_, false) => {
+            (
+                Representation::NormalInline | Representation::NormalHeap,
+                Representation::NormalHeap,
+            ) => {
                 let rhs_hb = $rhs.highest_set_bit();
                 if rhs_hb > $lhs.highest_set_bit() {
                     $lhs.ensure_capacity(rhs_hb);
@@ -56,8 +158,6 @@ macro_rules! extending_bitop_fn_body {
                 let lhs = unsafe { $lhs.as_slice_mut_unchecked() };
                 let rhs = unsafe { $rhs.as_slice_unchecked() };
 
-                assert!(lhs.len() >= rhs.len());
-
                 // in case lhs > rhs we need to have extra elements
                 let rhs_iter = rhs.iter().chain(iter::repeat(&0));
 
@@ -65,7 +165,7 @@ macro_rules! extending_bitop_fn_body {
                     $opa(lhs, *rhs);
                 }
             }
-            (false, true) => {
+            (Representation::NormalHeap, Representation::NormalInline) => {
                 let lhs = unsafe { $lhs.as_slice_mut_unchecked() };
                 let rhs = unsafe { $rhs.get_inline_data_unchecked() };
 
@@ -81,7 +181,7 @@ macro_rules! extending_bitop_fn_body {
 }
 
 macro_rules! impl_bitop {
-    ($($OP:ident :: $op:ident, $OPA:ident :: $opa:ident, $body_macro:path;)+) => {$(
+    ($($OP:ident :: $op:ident, $OPA:ident :: $opa:ident, $sparse_comp_closure:expr, $body_macro:path;)+) => {$(
         impl $OP<Self> for SmolBitSet {
             type Output = Self;
 
@@ -120,16 +220,20 @@ macro_rules! impl_bitop {
                     (*lhs).$opa(rhs);
                 }
 
-                $body_macro!(self, rhs, op);
+                fn sparse_cond(lhs: u32, rhs: u32) -> bool {
+                    $sparse_comp_closure(lhs, rhs)
+                }
+
+                $body_macro!(self, rhs, op, sparse_cond, $opa);
             }
         }
     )*};
 }
 
 impl_bitop! {
-    BitOr::bitor, BitOrAssign::bitor_assign, extending_bitop_fn_body;
-    BitAnd::bitand, BitAndAssign::bitand_assign, shortening_bitop_fn_body;
-    BitXor::bitxor, BitXorAssign::bitxor_assign, extending_bitop_fn_body;
+    BitOr::bitor, BitOrAssign::bitor_assign, |_, _| true, extending_bitop_fn_body;
+    BitAnd::bitand, BitAndAssign::bitand_assign, |lhs, rhs| lhs == rhs, shortening_bitop_fn_body;
+    BitXor::bitxor, BitXorAssign::bitxor_assign, |lhs, rhs| lhs != rhs, extending_bitop_fn_body;
 }
 
 macro_rules! impl_bitop_prim {
@@ -200,7 +304,11 @@ impl SmolBitSet {
             *lhs &= !rhs;
         }
 
-        shortening_bitop_fn_body!(self, rhs, op);
+        const fn sparse_cond(lhs_flag: u32, rhs_flag: u32) -> bool {
+            lhs_flag != rhs_flag
+        }
+
+        shortening_bitop_fn_body!(self, rhs, op, sparse_cond, and_not_assign);
     }
 }
 
@@ -240,10 +348,13 @@ mod tests {
         vec
     }
 
-    mod inline {
+    mod normal {
         use super::*;
 
-        macro_rules! test_inline_binops {
+        mod inline {
+            use super::*;
+
+            macro_rules! test_inline_bitops {
                 ($($name:ident, $a:expr, $b:expr),+) => {$(
                     #[test]
                     fn $name() {
@@ -261,18 +372,18 @@ mod tests {
                 )*}
             }
 
-        test_inline_binops! {
-            bitor, 0xF0F0u16, 0x0F0Fu16,
-            bitand, 0xFEFEu16, 0xAFFEu16,
-            bitxor, 0x3A52u16, 0xAAE8u16,
-            and_not, 0xFEFEu16, 0xAFFEu16
+            test_inline_bitops! {
+                bitor, 0xF0F0u16, 0x0F0Fu16,
+                bitand, 0xFEFEu16, 0xAFFEu16,
+                bitxor, 0x3A52u16, 0xAAE8u16,
+                and_not, 0xFEFEu16, 0xAFFEu16
+            }
         }
-    }
 
-    mod slice {
-        use super::*;
+        mod slice {
+            use super::*;
 
-        macro_rules! test_slice_binops {
+            macro_rules! test_slice_bitops {
                 ($($name:ident, $a:expr, $b:expr),+) => {$(
                     #[test]
                     fn $name() {
@@ -294,18 +405,18 @@ mod tests {
                 )*}
             }
 
-        test_slice_binops! {
-            bitor, 0xC0FF_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            bitand, 0xC0FF_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            bitxor, 0xC0FF_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            and_not, 0xC0FF_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64
+            test_slice_bitops! {
+                bitor, 0xC0FF_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                bitand, 0xC0FF_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                bitxor, 0xC0FF_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                and_not, 0xC0FF_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64
+            }
         }
-    }
 
-    mod mixed {
-        use super::*;
+        mod mixed {
+            use super::*;
 
-        macro_rules! test_mixed_binops {
+            macro_rules! test_mixed_bitops {
                 ($($name:ident, $a:expr, $b:expr),+) => {$(
                     #[test]
                     fn $name() {
@@ -329,38 +440,38 @@ mod tests {
                 )*}
             }
 
-        test_mixed_binops! {
-            bitor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            bitand, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            bitxor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64
+            test_mixed_bitops! {
+                bitor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                bitand, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                bitxor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64
+            }
+
+            // `a.and_not(b) != b.and_not(a)`
+            #[test]
+            fn and_not() {
+                const A: u64 = 0x0ABC_EE00_1337_BEEFu64;
+                const B: u64 = 0xF00D_BEEF_0420_BEEFu64;
+
+                let a = SmolBitSet::from(A);
+                let b = SmolBitSet::from(B);
+                assert!(a.is_inline());
+                assert_eq!(b.len(), 2);
+
+                let res1 = a.and_not(&b);
+                assert_eq!(
+                    to_bst_vec(&res1),
+                    [
+                        ((A as BitSliceType).and_not(B as BitSliceType)),
+                        (((A >> 32) as BitSliceType).and_not((B >> 32) as BitSliceType))
+                    ]
+                );
+            }
         }
 
-        // `a.and_not(b) != b.and_not(a)`
-        #[test]
-        fn and_not() {
-            const A: u64 = 0x0ABC_EE00_1337_BEEFu64;
-            const B: u64 = 0xF00D_BEEF_0420_BEEFu64;
+        mod rhs_smaller {
+            use super::*;
 
-            let a = SmolBitSet::from(A);
-            let b = SmolBitSet::from(B);
-            assert!(a.is_inline());
-            assert_eq!(b.len(), 2);
-
-            let res1 = a.and_not(&b);
-            assert_eq!(
-                to_bst_vec(&res1),
-                [
-                    ((A as BitSliceType).and_not(B as BitSliceType)),
-                    (((A >> 32) as BitSliceType).and_not((B >> 32) as BitSliceType))
-                ]
-            );
-        }
-    }
-
-    mod rhs_smaller {
-        use super::*;
-
-        macro_rules! test_rhs_smaller_binops {
+            macro_rules! test_rhs_smaller_bitops {
                 ($($name:ident, $a:expr, $b:expr),+) => {$(
                     #[test]
                     fn $name() {
@@ -383,18 +494,18 @@ mod tests {
                 )*};
             }
 
-        test_rhs_smaller_binops! {
-            bitor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            bitand, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            bitxor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            and_not, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64
+            test_rhs_smaller_bitops! {
+                bitor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                bitand, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                bitxor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                and_not, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64
+            }
         }
-    }
 
-    mod rhs_larger {
-        use super::*;
+        mod rhs_larger {
+            use super::*;
 
-        macro_rules! test_rhs_larger_binops {
+            macro_rules! test_rhs_larger_bitops {
                 ($($name:ident, $a:expr, $b:expr),+) => {$(
                     #[test]
                     fn $name() {
@@ -417,11 +528,165 @@ mod tests {
                 )*};
             }
 
-        test_rhs_larger_binops! {
-            bitor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            bitand, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            bitxor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
-            and_not, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64
+            test_rhs_larger_bitops! {
+                bitor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                bitand, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                bitxor, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64,
+                and_not, 0x0ABC_EE00_1337_BEEFu64, 0xF00D_BEEF_0420_BEEFu64
+            }
+        }
+    }
+
+    mod sparse {
+        use super::*;
+
+        mod inline {
+            use super::*;
+
+            macro_rules! test_sparse_inline_bitops {
+                ($($name:ident, $op:ident, $a:expr, $b:expr),+) => {$(
+                    #[test]
+                    fn $name() {
+                        let a = SmolBitSet::new_flag($a);
+                        let b = SmolBitSet::new_flag($b);
+                        assert!(a.is_inline());
+                        assert!(b.is_inline());
+                        assert!(a.is_sparse());
+                        assert!(b.is_sparse());
+
+                        let res = a.$op(&b);
+                        assert!(res.is_inline());
+
+                        let normal_res = (1usize << $a as usize).$op(1usize << $b as usize);
+                        if res.is_sparse() {
+                            let res_flag = unsafe { res.get_inline_sparse_data_unchecked() };
+                            assert_eq!(res_flag, normal_res.trailing_zeros());
+                        } else {
+                            let d = unsafe { res.get_inline_data_unchecked() };
+                            assert_eq!(d, normal_res);
+                        }
+                    }
+                )*}
+            }
+
+            test_sparse_inline_bitops! {
+                bitor_eq, bitor, 10, 10,
+                bitor_ne, bitor, 14, 18,
+
+                bitand_eq, bitand, 22, 22,
+                bitand_ne, bitand, 12, 22,
+
+                bitxor_eq, bitxor, 5, 5,
+                bitxor_ne, bitxor, 7, 24,
+
+                and_not_eq, and_not, 13, 13,
+                and_not_ne, and_not, 17, 19
+            }
+        }
+    }
+
+    mod mixed {
+        use super::*;
+
+        mod inline {
+            use super::*;
+
+            macro_rules! test_mixed_inline_bitops {
+                ($($name:ident, $op:ident, $a:expr, $b:expr),+) => {$(
+                    #[test]
+                    fn $name() {
+                        fn inner(a: SmolBitSet, b: SmolBitSet, a_u: usize, b_u: usize) {
+                            let res = a.$op(&b);
+                            assert!(res.is_inline());
+
+                            let normal_res = a_u.$op(b_u);
+
+                            if res.is_sparse() {
+                                let res_flag = unsafe { res.get_inline_sparse_data_unchecked() };
+                                assert_eq!(normal_res.count_ones(), 1);
+                                assert_eq!(res_flag, normal_res.trailing_zeros());
+                            } else {
+                                let d = unsafe { res.get_inline_data_unchecked() };
+                                assert_eq!(d, normal_res);
+                            }
+                        }
+
+                        let a = SmolBitSet::new_flag($a);
+                        let b = SmolBitSet::from($b);
+                        assert!(a.is_inline());
+                        assert!(a.is_sparse());
+                        assert!(b.is_inline());
+                        assert!(!b.is_sparse());
+
+                        let a_u = 1usize << $a as usize;
+                        let b_u = $b as usize;
+
+                        inner(a.clone(), b.clone(), a_u, b_u);
+                        inner(b, a, b_u, a_u);
+                    }
+                )*}
+            }
+
+            test_mixed_inline_bitops! {
+                bitor_eq, bitor, 10, 0xBEEFu16,
+                bitor_ne, bitor, 10, 0xF00Du16,
+
+                bitand_eq, bitand, 10, 0xBEEFu16,
+                bitand_ne, bitand, 10, 0xF00Du16,
+
+                bitxor_eq, bitxor, 10, 0xBEEFu16,
+                bitxor_ne, bitxor, 10, 0xF00Du16,
+
+                and_not_eq, and_not, 10, 0xBEEFu16,
+                and_not_ne, and_not, 10, 0xF00Du16
+            }
+        }
+
+        mod sparse_inline_normal_heap {
+            use super::*;
+
+            macro_rules! test_mixed_sparse_inline_normal_heap_bitops {
+                ($($name:ident, $op:ident, $a:expr, $b:expr),+) => {$(
+                    #[test]
+                    fn $name() {
+                        fn inner(a: SmolBitSet, b: SmolBitSet, a_u: usize, b_u: usize, shift: usize) {
+                            let res = a.$op(&b);
+
+                            let normal_res = a_u.$op(b_u);
+                            let shifted_res = SmolBitSet::from(normal_res) << shift;
+                            assert_eq!(res, shifted_res);
+                        }
+
+                        let shift = 120;
+                        let a: SmolBitSet = SmolBitSet::new_flag($a) << shift;
+                        let b: SmolBitSet = SmolBitSet::from($b) << shift;
+                        assert!(a.is_inline());
+                        assert!(a.is_sparse());
+                        assert!(!b.is_inline());
+                        assert!(!b.is_sparse());
+
+                        let a_u = 1usize << $a as usize;
+                        let b_u = $b as usize;
+
+                        inner(a.clone(), b.clone(), a_u, b_u, shift);
+                        inner(b, a, b_u, a_u, shift);
+                    }
+                )*}
+            }
+
+            test_mixed_sparse_inline_normal_heap_bitops! {
+                bitor_eq, bitor, 10, 0xBEEFu16,
+                bitor_ne, bitor, 10, 0xF00Du16,
+
+                bitand_eq, bitand, 10, 0xBEEFu16,
+                bitand_ne, bitand, 10, 0xF00Du16,
+
+                bitxor_eq, bitxor, 10, 0xBEEFu16,
+                bitxor_ne, bitxor, 10, 0xF00Du16,
+
+                and_not_eq, and_not, 10, 0xBEEFu16,
+                and_not_ne, and_not, 10, 0xF00Du16
+            }
         }
     }
 }

--- a/src/bst_slice.rs
+++ b/src/bst_slice.rs
@@ -9,6 +9,8 @@ pub enum BstSlice<'a> {
 
 impl<'a> BstSlice<'a> {
     pub fn new(sbs: &'a SmolBitSet) -> Self {
+        debug_assert!(!sbs.is_sparse());
+
         if sbs.is_inline() {
             let data = unsafe { sbs.get_inline_data_unchecked() };
             #[cfg(target_pointer_width = "32")]

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -1,24 +1,53 @@
 use crate::bst_slice::BstSlice;
-use crate::{BitSliceType, SmolBitSet};
+use crate::{BitSliceType, Representation, SmolBitSet};
 
 use core::{cmp, iter};
 
 impl cmp::PartialEq for SmolBitSet {
     fn eq(&self, other: &Self) -> bool {
-        let this = BstSlice::new(self);
-        let other = BstSlice::new(other);
+        fn inner(this: &BstSlice<'_>, other: &BstSlice<'_>) -> bool {
+            let this = this.slice();
+            let other = other.slice();
 
-        let this = this.slice();
-        let other = other.slice();
+            let (long, short) = if this.len() >= other.len() {
+                (this, other)
+            } else {
+                (other, this)
+            };
 
-        let (long, short) = if this.len() >= other.len() {
-            (this, other)
-        } else {
-            (other, this)
-        };
+            let (prefix, suffix) = long.split_at(short.len());
+            prefix == short && suffix.iter().all(|&x| x == 0)
+        }
 
-        let (prefix, suffix) = long.split_at(short.len());
-        prefix == short && suffix.iter().all(|&x| x == 0)
+        match (self.representation(), other.representation()) {
+            (Representation::SparseInline, Representation::SparseInline) => {
+                let this = unsafe { self.get_inline_sparse_data_unchecked() };
+                let other = unsafe { other.get_inline_sparse_data_unchecked() };
+                this == other
+            }
+            (
+                Representation::SparseInline,
+                Representation::NormalInline | Representation::NormalHeap,
+            ) => {
+                let normalized_self = self.as_normal();
+                let this = BstSlice::new(&normalized_self);
+                let other = BstSlice::new(other);
+                inner(&this, &other)
+            }
+            (
+                Representation::NormalInline | Representation::NormalHeap,
+                Representation::SparseInline,
+            ) => {
+                let normalized_other = other.as_normal();
+                let this = BstSlice::new(self);
+                let other = BstSlice::new(&normalized_other);
+                inner(&this, &other)
+            }
+            (
+                Representation::NormalHeap | Representation::NormalInline,
+                Representation::NormalHeap | Representation::NormalInline,
+            ) => inner(&BstSlice::new(self), &BstSlice::new(other)),
+        }
     }
 }
 
@@ -32,7 +61,7 @@ impl cmp::PartialOrd for SmolBitSet {
 
 impl cmp::Ord for SmolBitSet {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        fn inner(long: &[BitSliceType], short: &[BitSliceType]) -> cmp::Ordering {
+        fn slice_cmp(long: &[BitSliceType], short: &[BitSliceType]) -> cmp::Ordering {
             let (prefix, suffix) = long.split_at(short.len());
             if suffix.iter().any(|&x| x != 0) {
                 return cmp::Ordering::Greater;
@@ -48,16 +77,45 @@ impl cmp::Ord for SmolBitSet {
             cmp::Ordering::Equal
         }
 
-        let this = BstSlice::new(self);
-        let other = BstSlice::new(other);
+        fn inner(this: &BstSlice<'_>, other: &BstSlice<'_>) -> cmp::Ordering {
+            let this = this.slice();
+            let other = other.slice();
 
-        let this = this.slice();
-        let other = other.slice();
+            if this.len() >= other.len() {
+                slice_cmp(this, other)
+            } else {
+                slice_cmp(other, this).reverse()
+            }
+        }
 
-        if this.len() >= other.len() {
-            inner(this, other)
-        } else {
-            inner(other, this).reverse()
+        match (self.representation(), other.representation()) {
+            (Representation::SparseInline, Representation::SparseInline) => {
+                let this = unsafe { self.get_inline_sparse_data_unchecked() };
+                let other = unsafe { other.get_inline_sparse_data_unchecked() };
+                this.cmp(&other)
+            }
+            (
+                Representation::SparseInline,
+                Representation::NormalInline | Representation::NormalHeap,
+            ) => {
+                let normalized_self = self.as_normal();
+                let this = BstSlice::new(&normalized_self);
+                let other = BstSlice::new(other);
+                inner(&this, &other)
+            }
+            (
+                Representation::NormalInline | Representation::NormalHeap,
+                Representation::SparseInline,
+            ) => {
+                let normalized_other = other.as_normal();
+                let this = BstSlice::new(self);
+                let other = BstSlice::new(&normalized_other);
+                inner(&this, &other)
+            }
+            (
+                Representation::NormalHeap | Representation::NormalInline,
+                Representation::NormalHeap | Representation::NormalInline,
+            ) => inner(&BstSlice::new(self), &BstSlice::new(other)),
         }
     }
 }
@@ -66,74 +124,140 @@ impl cmp::Ord for SmolBitSet {
 mod tests {
     use super::*;
 
-    #[test]
-    fn eq() {
-        let mut a = SmolBitSet::from(u16::MAX);
-        let mut b = SmolBitSet::from(0xFFFFu16);
-        assert_eq!(a, b);
+    mod normal {
+        use super::*;
 
-        a <<= 55;
-        assert_ne!(a, b);
+        #[test]
+        fn eq() {
+            let mut a = SmolBitSet::from(u16::MAX);
+            let mut b = SmolBitSet::from(0xFFFFu16);
+            assert_eq!(a, b);
 
-        b <<= 55;
-        assert_eq!(a, b);
+            a <<= 55;
+            assert_ne!(a, b);
+
+            b <<= 55;
+            assert_eq!(a, b);
+        }
+
+        #[test]
+        fn ord() {
+            let mut a = SmolBitSet::from(0xBEEFu16);
+            let mut b = SmolBitSet::from(0x00C5_F00Du32);
+            assert!(a < b);
+
+            a <<= 72;
+            assert!(a > b);
+            assert!(b < a);
+
+            b <<= 72;
+            assert!(a < b);
+        }
+
+        #[test]
+        fn eq_but_not_physical_same() {
+            let mut a = SmolBitSet::from(u16::MAX);
+            let mut b = SmolBitSet::from(0xFFFFu16);
+
+            // ensure a is larger than b in memory
+            a.spill(256);
+
+            assert_eq!(a, b);
+            assert_eq!(b, a);
+
+            a <<= 55;
+            assert_ne!(a, b);
+            assert_ne!(b, a);
+
+            b <<= 55;
+            assert_eq!(a, b);
+            assert_eq!(b, a);
+        }
+
+        #[test]
+        fn ord_but_not_physical_same() {
+            let mut a = SmolBitSet::from(0xBEEFu16);
+            let mut b = SmolBitSet::from(0x00C5_F00Du32);
+
+            // ensure a is larger than b in memory
+            a.spill(256);
+
+            assert!(a < b);
+            assert!(b > a);
+
+            a <<= 18;
+            assert!(a > b);
+            assert!(b < a);
+
+            a <<= 54;
+            assert!(a > b);
+            assert!(b < a);
+
+            b <<= 72;
+            assert!(a < b);
+            assert!(b > a);
+        }
     }
 
-    #[test]
-    fn ord() {
-        let mut a = SmolBitSet::from(0xBEEFu16);
-        let mut b = SmolBitSet::from(0x00C5_F00Du32);
-        assert!(a < b);
+    mod sparse {
+        use super::*;
 
-        a <<= 72;
-        assert!(a > b);
-        assert!(b < a);
+        #[test]
+        fn eq() {
+            let mut a = SmolBitSet::new_flag(12345);
+            let mut b = SmolBitSet::new_flag(12345);
+            assert_eq!(a, b);
 
-        b <<= 72;
-        assert!(a < b);
+            a <<= 550;
+            assert_ne!(a, b);
+
+            b <<= 550;
+            assert_eq!(a, b);
+        }
+
+        #[test]
+        fn ord() {
+            let mut a = SmolBitSet::new_flag(12345);
+            let mut b = SmolBitSet::new_flag(54321);
+            assert!(a < b);
+
+            a <<= 100_000;
+            assert!(a > b);
+            assert!(b < a);
+
+            b <<= 100_000;
+            assert!(a < b);
+        }
     }
 
-    #[test]
-    fn eq_but_not_physical_same() {
-        let mut a = SmolBitSet::from(u16::MAX);
-        let mut b = SmolBitSet::from(0xFFFFu16);
+    mod mixed {
+        use super::*;
 
-        // ensure a is larger than b in memory
-        a.spill(256);
+        #[test]
+        fn eq() {
+            let mut a = SmolBitSet::new_small(1 << 22);
+            let mut b = SmolBitSet::new_flag(22);
+            assert_eq!(a, b);
 
-        assert_eq!(a, b);
-        assert_eq!(b, a);
+            a <<= 32;
+            assert_ne!(a, b);
 
-        a <<= 55;
-        assert_ne!(a, b);
-        assert_ne!(b, a);
+            b <<= 32;
+            assert_eq!(a, b);
+        }
 
-        b <<= 55;
-        assert_eq!(a, b);
-        assert_eq!(b, a);
-    }
+        #[test]
+        fn ord() {
+            let mut a = SmolBitSet::new_small(1);
+            let mut b = SmolBitSet::new_flag(22);
+            assert!(a < b);
 
-    #[test]
-    fn ord_but_not_physical_same() {
-        let mut a = SmolBitSet::from(0xBEEFu16);
-        let mut b = SmolBitSet::from(0x00C5_F00Du32);
+            a <<= 80;
+            assert!(a > b);
+            assert!(b < a);
 
-        // ensure a is larger than b in memory
-        a.spill(256);
-
-        assert!(a < b);
-        assert!(b > a);
-
-        a <<= 18;
-        assert!(a > b);
-        assert!(b < a);
-
-        a <<= 54;
-        assert!(a > b);
-        assert!(b < a);
-
-        b <<= 72;
-        assert!(a < b);
-        assert!(b > a);
+            b <<= 80;
+            assert!(a < b);
+        }
     }
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -11,12 +11,20 @@ use fmt::{Binary, Debug, Display, Formatter, LowerHex, Octal, Result, UpperHex};
 
 impl Debug for SmolBitSet {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        if self.is_sparse() {
+            return Debug::fmt(&self.as_normal(), f);
+        }
+
         f.debug_list().entries(BstSlice::new(self).slice()).finish()
     }
 }
 
 impl Display for SmolBitSet {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        if self.is_sparse() {
+            return Display::fmt(&self.as_normal(), f);
+        }
+
         if self.is_inline() {
             return write!(f, "{}", unsafe { self.get_inline_data_unchecked() });
         }
@@ -30,6 +38,10 @@ macro_rules! impl_format {
     ($($kind:ident $format:literal $variants:literal),+) => {$(
         impl $kind for SmolBitSet {
             fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+                if self.is_sparse() {
+                    return $kind::fmt(&self.as_normal(), f);
+                }
+
                 if self.is_inline() {
                     return $kind::fmt(&unsafe { self.get_inline_data_unchecked() }, f);
                 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -7,6 +7,11 @@ use std::hash;
 
 impl hash::Hash for SmolBitSet {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        if self.is_sparse() {
+            self.as_normal().hash(state);
+            return;
+        }
+
         if self.is_inline() {
             unsafe { self.get_inline_data_unchecked() }.hash(state);
             return;
@@ -37,14 +42,20 @@ mod tests {
 
     use super::*;
 
-    fn assert_hash_eq(a: &SmolBitSet, b: &SmolBitSet) {
+    fn hash_helper(a: &SmolBitSet) -> u64 {
         use hash::{DefaultHasher, Hash, Hasher};
 
-        let mut hasher_a = DefaultHasher::new();
-        let mut hasher_b = DefaultHasher::new();
-        a.hash(&mut hasher_a);
-        b.hash(&mut hasher_b);
-        assert_eq!(hasher_a.finish(), hasher_b.finish());
+        let mut hasher = DefaultHasher::new();
+        a.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn assert_hash_eq(a: &SmolBitSet, b: &SmolBitSet) {
+        assert_eq!(hash_helper(a), hash_helper(b));
+    }
+
+    fn assert_hash_ne(a: &SmolBitSet, b: &SmolBitSet) {
+        assert_ne!(hash_helper(a), hash_helper(b));
     }
 
     #[test]
@@ -56,7 +67,38 @@ mod tests {
 
         a >>= 1u8;
         b >>= 4u8;
+        assert_hash_ne(&a, &b);
+
         a >>= 3u8;
+        assert_hash_eq(&a, &b);
+    }
+
+    #[test]
+    fn sparse_inline() {
+        let flag = 1337;
+        let mut a = SmolBitSet::new_flag(flag);
+        let mut b = SmolBitSet::new_flag(flag);
+        assert_hash_eq(&a, &b);
+
+        a <<= 42u8;
+        b <<= 66u8;
+        assert_hash_ne(&a, &b);
+
+        a <<= 24u8;
+        assert_hash_eq(&a, &b);
+    }
+
+    #[test]
+    fn mixed_inline() {
+        let mut a = SmolBitSet::new_small(1 << 15);
+        let mut b = SmolBitSet::new_flag(15);
+        assert_hash_eq(&a, &b);
+
+        b <<= 420u16;
+        a >>= 5u8;
+        assert_hash_ne(&a, &b);
+
+        b >>= 425u16;
         assert_hash_eq(&a, &b);
     }
 
@@ -71,6 +113,8 @@ mod tests {
 
         a <<= 128u8;
         a >>= 66u8;
+        assert_hash_ne(&a, &b);
+
         b <<= 128u8 - 66u8;
         assert_hash_eq(&a, &b);
     }
@@ -86,6 +130,8 @@ mod tests {
         assert_hash_eq(&a, &b);
 
         a >>= 5u8;
+        assert_hash_ne(&a, &b);
+
         b >>= 5u8;
         assert_hash_eq(&a, &b);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A library for dynamically sized bitsets with memory usage optimizations.
 //!
-//! The first <code>[usize::BITS] - 1</code> bits are stored without incurring any heap allocations.\
+//! The first <code>[usize::BITS] - 2</code> bits are stored without incurring any heap allocations.\
 //! Any larger values dynamically allocate an appropriately sized [`u32`] slice on the heap.\
 //! Furthermore [`SmolBitSet`] has a niche optimization so [`Option<SmolBitSet>`] has the same size of 1 [`usize`].
 //!
@@ -77,15 +77,32 @@ type BitSliceType = u32;
 
 /// How many bits are used for other purposes in the pointer which also determines
 /// the required alignment since we use the least significant bits for this header information.
-/// Bit 0: inline(1) / heap(0) flag
-const HEADER_SIZE: u32 = 1;
+///
+/// Bit 0 is used to determine whether the data is stored inline or on the heap (0 = heap, 1 = inline).\
+/// Bit 1 is used to determine the mode in which the bits are represented (0 = normal, 1 = sparse).\
+/// Sparse mode is an optimization for bitsets with very few bits set to 1.
+/// In this mode the set bits are stored as a list of indices instead.\
+/// This also allows us to create a [`SmolBitSet`] in const contexts for bit values that would not fit
+/// in the normal inline representation.
+const HEADER_SIZE: u32 = 2;
+
+enum Representation {
+    NormalInline = 0b01,
+    /// Sparse has no way to represent an empty set so it gets switched to normal inline instead
+    SparseInline = 0b11,
+    NormalHeap = 0b00,
+    // SparseHeap = 0b10, // TODO: evaluate & implement sparse heap representation
+}
+
 const BST_BITS: usize = BitSliceType::BITS as usize;
 const INLINE_SLICE_PARTS: usize = usize::BITS as usize / BST_BITS;
 const MAX_INLINE_BITS: usize = (usize::BITS - HEADER_SIZE) as usize;
+const MAX_INLINE_VAL: usize = usize::MAX >> HEADER_SIZE;
+const MAX_INLINE_SPARSE_VAL: BitSliceType = (BitSliceType::MAX >> HEADER_SIZE) as BitSliceType;
 
 /// A dynamically sized bitset with memory usage optimizations.
 ///
-/// The first <code>[usize::BITS] - 1</code> bits are stored without incurring any heap allocations.
+/// The first <code>[usize::BITS] - 2</code> bits are stored without incurring any heap allocations.
 #[repr(transparent)]
 pub struct SmolBitSet {
     ptr: NonNull<BitSliceType>,
@@ -112,7 +129,7 @@ impl SmolBitSet {
     ///
     /// # Panics
     ///
-    /// Panics if the most significant bit in `val` is 1.
+    /// Panics if any of the 2 most significant bits in `val` is 1.
     ///
     /// # Examples
     ///
@@ -124,8 +141,8 @@ impl SmolBitSet {
     #[must_use]
     pub const fn new_small(val: usize) -> Self {
         assert!(
-            val.leading_zeros() >= HEADER_SIZE,
-            "the highest bit in val must be 0 for a non allocating SmolBitSet"
+            val <= MAX_INLINE_VAL,
+            "val too large for a non allocating SmolBitSet"
         );
 
         let mut res = Self::new();
@@ -136,11 +153,39 @@ impl SmolBitSet {
         res
     }
 
+    /// Constructs a new sparse [`SmolBitSet`] from the provided `bit` index without any heap allocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bit` is larger than <code>2^30</code>.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use smolbitset::SmolBitSet;
+    /// const sbs: SmolBitSet = SmolBitSet::new_flag(1234);
+    /// assert_eq!(sbs, SmolBitSet::new_flag(0) << 1234);
+    /// ```
+    #[must_use]
+    pub const fn new_flag(bit: BitSliceType) -> Self {
+        assert!(
+            bit <= MAX_INLINE_SPARSE_VAL,
+            "bit index out of range for a non allocating sparse SmolBitSet"
+        );
+
+        let mut res = Self::new();
+        unsafe {
+            res.write_inline_sparse_data_unchecked(bit);
+        }
+
+        res
+    }
+
     /// Constructs a new [`SmolBitSet`] from the provided array of bit indices without any heap allocations.
     ///
     /// # Panics
     ///
-    /// Panics if any bit index in `bits` is larger than or equal to [`usize::BITS`].
+    /// Panics if any bit index in `bits` is larger than or equal to <code>[usize::BITS] - 2</code>.
     ///
     /// # Examples
     ///
@@ -152,16 +197,16 @@ impl SmolBitSet {
     ///
     /// ```should_panic
     /// # use smolbitset::SmolBitSet;
-    /// // this panics since 63 is outside of the range
+    /// // this panics since 62 is outside of the range
     /// // a SmolBitSet can hold without incurring a heap allocation
-    /// let sbs = SmolBitSet::from_bits_small([63]);
+    /// let sbs = SmolBitSet::from_bits_small([62]);
     /// ```
     ///
     /// ```compile_fail
     /// # use smolbitset::SmolBitSet;
     /// // this fails to compile since the const evaluation
     /// // panics for the same reason as above
-    /// const sbs: SmolBitSet = SmolBitSet::from_bits_small([63]);
+    /// const sbs: SmolBitSet = SmolBitSet::from_bits_small([62]);
     /// ```
     #[must_use]
     pub const fn from_bits_small<const N: usize>(bits: [usize; N]) -> Self {
@@ -171,7 +216,7 @@ impl SmolBitSet {
         while i < N {
             let b = bits[i];
             assert!(
-                b < (usize::BITS - HEADER_SIZE) as usize,
+                b < MAX_INLINE_BITS,
                 "bit index out of range for a non allocating SmolBitSet"
             );
 
@@ -197,6 +242,8 @@ impl SmolBitSet {
     /// ```
     #[must_use]
     pub fn from_bits(bits: &[usize]) -> Self {
+        // TODO: check if sparse representation would be more efficient for the given bit indices
+
         let Some(hb) = bits.iter().copied().max() else {
             return Self::new();
         };
@@ -226,8 +273,19 @@ impl SmolBitSet {
     }
 
     #[inline]
+    // #[deprecated = "use `SmolBitSet::representation` instead"]
     fn is_inline(&self) -> bool {
         self.ptr.addr().get() & 0b1 == 1
+    }
+
+    #[inline]
+    fn representation(&self) -> Representation {
+        match self.ptr.addr().get() & 0b11 {
+            0b00 => Representation::NormalHeap,
+            0b01 => Representation::NormalInline,
+            0b11 => Representation::SparseInline,
+            _ => unreachable!(),
+        }
     }
 
     #[inline]
@@ -237,7 +295,35 @@ impl SmolBitSet {
 
     #[inline]
     const unsafe fn write_inline_data_unchecked(&mut self, data: usize) {
-        let addr = unsafe { NonZero::new_unchecked((data << HEADER_SIZE) | 0b1) };
+        debug_assert!(data <= MAX_INLINE_VAL);
+
+        let addr = unsafe { NonZero::new_unchecked((data << HEADER_SIZE) | 0b01) };
+        self.ptr = NonNull::without_provenance(addr);
+    }
+
+    #[inline]
+    // #[deprecated = "use `SmolBitSet::representation` instead"]
+    fn is_sparse(&self) -> bool {
+        self.ptr.addr().get() & 0b10 != 0
+    }
+
+    #[inline]
+    fn set_sparse(&mut self, sparse: bool) {
+        let addr = self.ptr.addr().get();
+        let new_addr = if sparse { addr | 0b10 } else { addr & !0b10 };
+        let addr = unsafe { NonZero::new_unchecked(new_addr) };
+        self.ptr = NonNull::without_provenance(addr);
+    }
+
+    unsafe fn get_inline_sparse_data_unchecked(&self) -> BitSliceType {
+        (self.ptr.addr().get() >> HEADER_SIZE) as BitSliceType
+    }
+
+    #[inline]
+    const unsafe fn write_inline_sparse_data_unchecked(&mut self, data: BitSliceType) {
+        debug_assert!(data <= MAX_INLINE_SPARSE_VAL);
+
+        let addr = unsafe { NonZero::new_unchecked(((data as usize) << HEADER_SIZE) | 0b11) };
         self.ptr = NonNull::without_provenance(addr);
     }
 
@@ -286,6 +372,20 @@ impl SmolBitSet {
     #[inline]
     const unsafe fn as_slice_mut_unchecked(&mut self) -> &mut [BitSliceType] {
         unsafe { slice::from_raw_parts_mut(self.data_ptr_unchecked(), self.len_unchecked()) }
+    }
+
+    fn as_normal(&self) -> Self {
+        if !self.is_sparse() {
+            return self.clone();
+        }
+
+        debug_assert!(
+            self.is_inline(),
+            "sparse heap representation is not implemented yet"
+        );
+
+        let flag = unsafe { self.get_inline_sparse_data_unchecked() };
+        Self::new_small(1) << flag
     }
 
     /// # Warning
@@ -338,7 +438,7 @@ impl SmolBitSet {
     #[inline]
     fn ensure_capacity(&mut self, highest_bit: usize) {
         if self.is_inline() {
-            if highest_bit > (usize::BITS - HEADER_SIZE) as usize {
+            if highest_bit > MAX_INLINE_BITS {
                 unsafe { self.do_spill(highest_bit) }
             }
 
@@ -389,24 +489,33 @@ impl SmolBitSet {
     /// The least significant bit is at index 1!
     #[inline]
     fn highest_set_bit(&self) -> usize {
-        if self.is_inline() {
-            let data = unsafe { self.get_inline_data_unchecked() };
-            return highest_set_bit!(usize, data);
-        }
+        match self.representation() {
+            Representation::NormalInline => {
+                let data = unsafe { self.get_inline_data_unchecked() };
+                highest_set_bit!(usize, data)
+            }
+            Representation::NormalHeap => {
+                let data = unsafe { self.as_slice_unchecked() };
+                for (idx, &data) in data.iter().enumerate().rev() {
+                    let h = highest_set_bit!(BitSliceType, data);
+                    if h != 0 {
+                        return (idx * BST_BITS) + h;
+                    }
+                }
 
-        let data = unsafe { self.as_slice_unchecked() };
-        for (idx, &data) in data.iter().enumerate().rev() {
-            let h = highest_set_bit!(BitSliceType, data);
-            if h != 0 {
-                return (idx * BST_BITS) + h;
+                0
+            }
+            Representation::SparseInline => {
+                let data = unsafe { self.get_inline_sparse_data_unchecked() };
+                data as usize + 1
             }
         }
-
-        0
     }
 
     /// Gets the starting bits that could be stored inlined.
     fn get_inlineable_start(&self) -> usize {
+        debug_assert!(!self.is_sparse());
+
         if self.is_inline() {
             let data = unsafe { self.get_inline_data_unchecked() };
             return data;
@@ -561,7 +670,7 @@ mod tests {
         t.ensure_capacity(32);
         assert!(t.is_inline());
 
-        let max_inline = (usize::BITS - HEADER_SIZE) as usize;
+        let max_inline = MAX_INLINE_BITS;
         t.ensure_capacity(max_inline);
         assert!(t.is_inline());
 

--- a/src/shifts.rs
+++ b/src/shifts.rs
@@ -7,6 +7,22 @@ fn sbs_shl(sbs: &mut SmolBitSet, rhs: usize) {
         return;
     }
 
+    if sbs.is_sparse() {
+        let flag = unsafe { sbs.get_inline_sparse_data_unchecked() };
+        let rhs = rhs
+            .try_into()
+            .expect("Cannot shift left by an amount larger than u32::MAX");
+        let new_flag = flag
+            .checked_add(rhs)
+            .expect("Cannot shift left by an amount that causes overflow");
+
+        unsafe {
+            sbs.write_inline_sparse_data_unchecked(new_flag);
+        }
+
+        return;
+    }
+
     let hb: usize = sbs.highest_set_bit();
     sbs.ensure_capacity(hb + rhs);
 
@@ -51,6 +67,24 @@ fn sbs_shl(sbs: &mut SmolBitSet, rhs: usize) {
 
 fn sbs_shr(sbs: &mut SmolBitSet, rhs: usize) {
     if rhs == 0 {
+        return;
+    }
+
+    if sbs.is_sparse() {
+        let flag = unsafe { sbs.get_inline_sparse_data_unchecked() };
+        let rhs = rhs.try_into().unwrap_or(u32::MAX);
+        let new_flag = flag.checked_sub(rhs);
+
+        match new_flag {
+            Some(f) => unsafe {
+                sbs.write_inline_sparse_data_unchecked(f);
+            },
+            None => {
+                // bitset is now empty, switching to non-sparse inline representation
+                *sbs = SmolBitSet::new();
+            }
+        }
+
         return;
     }
 
@@ -256,6 +290,27 @@ mod tests {
             assert_eq!(a.len(), 5);
             assert_eq!(a.as_slice(), [0, 0, 0, 0xAFFE_BEEFu32, 0xFFEE_00AAu32]);
         }
+
+        #[test]
+        fn sparse_inline() {
+            let flag = 0;
+            let mut a = SmolBitSet::new_flag(flag);
+            assert!(a.is_inline());
+            assert!(a.is_sparse());
+
+            a <<= 6u8;
+            assert!(a.is_inline());
+            assert!(a.is_sparse());
+            assert_eq!(unsafe { a.get_inline_sparse_data_unchecked() }, flag + 6);
+
+            let b = a << u16::MAX;
+            assert!(b.is_inline());
+            assert!(b.is_sparse());
+            assert_eq!(
+                unsafe { b.get_inline_sparse_data_unchecked() },
+                flag + 6 + u16::MAX as u32
+            );
+        }
     }
 
     mod shr {
@@ -312,6 +367,35 @@ mod tests {
             a >>= 64u8;
             assert_eq!(a.len(), 2);
             assert_eq!(a.as_slice(), [0, 0]);
+        }
+
+        #[test]
+        fn sparse_inline() {
+            let flag = u16::MAX as u32;
+            let mut a = SmolBitSet::new_flag(flag);
+            assert!(a.is_inline());
+            assert!(a.is_sparse());
+
+            a >>= 10u8;
+            assert!(a.is_inline());
+            assert!(a.is_sparse());
+            assert_eq!(
+                unsafe { a.get_inline_sparse_data_unchecked() },
+                flag.saturating_sub(10)
+            );
+
+            let b = a >> 420u16;
+            assert!(b.is_inline());
+            assert!(b.is_sparse());
+            assert_eq!(
+                unsafe { b.get_inline_sparse_data_unchecked() },
+                flag.saturating_sub(10 + 420)
+            );
+
+            let c = b >> u16::MAX;
+            assert!(c.is_inline());
+            assert!(!c.is_sparse());
+            assert_eq!(unsafe { c.get_inline_data_unchecked() }, 0);
         }
     }
 


### PR DESCRIPTION
New representation mode which makes it possible to create a `SmolBitSet` with a single 1 bit in `const` contexts for bit indices up to 1073741824 (2^30).
This should make the integration into serenity way nicer in the end.

Sparse mode is currently only implemented for the inline representation. Technically it is also possible to use it in the heap representation but that needs some more work in a future PR.